### PR TITLE
Support installation from EPEL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ end
 
 ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
+minor_version = '2.7'
 
 group :development do
   gem "fast_gettext", '1.1.0',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,10 @@
 #   include ::apptainer
 #
 # @param install_method
-#   Sets how Apptainer will be installed
+#   Sets how Apptainer will be installed,
+#   `package` will install the upstream package
+#   `source` from source
+#   `os` will install from standard OS repositories for example from EPEL on RedHat family.
 # @param install_setuid
 #   Whether to install the setuid portion of apptainer
 # @param version
@@ -151,7 +154,7 @@
 #   The template to use for /etc/subuid and /etc/subgid
 #
 class apptainer (
-  Enum['package','source'] $install_method = 'package',
+  Enum['package','source','os'] $install_method = 'package',
   Boolean $install_setuid = false,
   String $version = '1.1.3',
   Boolean $manage_repo = true,

--- a/manifests/install/os.pp
+++ b/manifests/install/os.pp
@@ -1,0 +1,24 @@
+# @summary Private class
+# @api private
+class apptainer::install::os {
+  assert_private()
+
+  if $facts['os']['family'] == 'RedHat' {
+
+    package { 'apptainer':
+      ensure => $apptainer::version,
+    }
+
+    $_suid_ensure = $apptainer::install_setuid ? {
+      true    => $apptainer::version,
+      default => 'absent',
+    }
+
+    package { 'apptainer-suid':
+      ensure => $_suid_ensure,
+    }
+
+  } else {
+    fail('Module apptainer only supports os installs on RedHat')
+  }
+}

--- a/spec/acceptance/01_class_spec.rb
+++ b/spec/acceptance/01_class_spec.rb
@@ -3,6 +3,79 @@
 require 'spec_helper_acceptance'
 
 describe 'apptainer class:' do
+  context 'install os package', if: fact('os.family') == 'RedHat' do
+    it 'runs successfully' do
+      pp = <<-EOS
+      class { 'apptainer':
+        version        => 'installed',
+        install_method => 'os',
+        install_setuid => true,
+        # Avoid /etc/localtime which may not exist in minimal Docker environments
+        bind_paths     => ['/etc/hosts'],
+      }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/etc/apptainer/apptainer.conf') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_mode 644 }
+      it { is_expected.to be_owned_by 'root' }
+      it { is_expected.to be_grouped_into 'root' }
+    end
+
+    describe package('apptainer') do
+      it { is_expected.to be_installed }
+    end
+
+    describe package('apptainer-suid') do
+      it { is_expected.to be_installed }
+    end
+
+    describe command('apptainer exec docker://alpine cat /etc/alpine-release') do
+      its(:exit_status) { is_expected.to eq(0) }
+      its(:stdout) { is_expected.to match %r{[0-9]+.[0-9]+.[0-9]+} }
+    end
+  end
+
+  context 'remove os package', if: fact('os.family') == 'RedHat' do
+    it 'runs successfully' do
+      pp = <<-EOS
+        package{['apptainer-suid', 'apptainer']:
+          ensure => 'absent',
+        }
+        Package['apptainer-suid'] -> Package['apptainer']
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe package('apptainer') do
+      it { is_expected.not_to be_installed }
+    end
+
+    describe package('apptainer-suid') do
+      it { is_expected.not_to be_installed }
+    end
+  end
+
+  context 'add singularity' do
+    it 'runs successfully' do
+      pp = <<-EOS
+      class { 'singularity':
+        # Avoid /etc/localtime which may not exist in minimal Docker environments
+        bind_paths => ['/etc/hosts'],
+      }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+  end
+
   context 'with default parameters', if: fact('os.family') == 'RedHat' do
     let(:version) { '1.1.0' }
 

--- a/spec/acceptance/01_class_spec.rb
+++ b/spec/acceptance/01_class_spec.rb
@@ -54,7 +54,6 @@ describe 'apptainer class:' do
     end
   end
 
- 
   context 'with default parameters', if: fact('os.family') == 'RedHat' do
     let(:version) { '1.1.0' }
 

--- a/spec/acceptance/01_class_spec.rb
+++ b/spec/acceptance/01_class_spec.rb
@@ -26,7 +26,7 @@ describe 'apptainer class:' do
       it { is_expected.to be_grouped_into 'root' }
     end
 
-    describe package(['apptainer', 'apptainer-suid']) do
+    describe package('apptainer') do
       it { is_expected.to be_installed }
     end
 

--- a/spec/acceptance/01_class_spec.rb
+++ b/spec/acceptance/01_class_spec.rb
@@ -54,20 +54,7 @@ describe 'apptainer class:' do
     end
   end
 
-  context 'with singularity' do
-    it 'runs successfully' do
-      pp = <<-EO_SINGULARITY
-      class { 'singularity':
-        # Avoid /etc/localtime which may not exist in minimal Docker environments
-        bind_paths => ['/etc/hosts'],
-      }
-      EO_SINGULARITY
-
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
-    end
-  end
-
+ 
   context 'with default parameters', if: fact('os.family') == 'RedHat' do
     let(:version) { '1.1.0' }
 

--- a/spec/acceptance/01_class_spec.rb
+++ b/spec/acceptance/01_class_spec.rb
@@ -3,9 +3,9 @@
 require 'spec_helper_acceptance'
 
 describe 'apptainer class:' do
-  context 'install os package', if: fact('os.family') == 'RedHat' do
+  context 'with install os package', if: fact('os.family') == 'RedHat' do
     it 'runs successfully' do
-      pp = <<-EOS
+      pp = <<-PUPPET_PP
       class { 'apptainer':
         version        => 'installed',
         install_method => 'os',
@@ -13,7 +13,7 @@ describe 'apptainer class:' do
         # Avoid /etc/localtime which may not exist in minimal Docker environments
         bind_paths     => ['/etc/hosts'],
       }
-      EOS
+      PUPPET_PP
 
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
@@ -26,11 +26,7 @@ describe 'apptainer class:' do
       it { is_expected.to be_grouped_into 'root' }
     end
 
-    describe package('apptainer') do
-      it { is_expected.to be_installed }
-    end
-
-    describe package('apptainer-suid') do
+    describe package(['apptainer', 'apptainer-suid']) do
       it { is_expected.to be_installed }
     end
 
@@ -40,36 +36,32 @@ describe 'apptainer class:' do
     end
   end
 
-  context 'remove os package', if: fact('os.family') == 'RedHat' do
+  context 'with remove os package', if: fact('os.family') == 'RedHat' do
     it 'runs successfully' do
-      pp = <<-EOS
+      pp = <<-PUPPET_PP
         package{['apptainer-suid', 'apptainer']:
           ensure => 'absent',
         }
         Package['apptainer-suid'] -> Package['apptainer']
-      EOS
+      PUPPET_PP
 
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
 
-    describe package('apptainer') do
-      it { is_expected.not_to be_installed }
-    end
-
-    describe package('apptainer-suid') do
+    describe package(['apptainer', 'apptainer-suid']) do
       it { is_expected.not_to be_installed }
     end
   end
 
-  context 'add singularity' do
+  context 'with singularity' do
     it 'runs successfully' do
-      pp = <<-EOS
+      pp = <<-EO_SINGULARITY
       class { 'singularity':
         # Avoid /etc/localtime which may not exist in minimal Docker environments
         bind_paths => ['/etc/hosts'],
       }
-      EOS
+      EO_SINGULARITY
 
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -30,6 +30,30 @@ describe 'apptainer' do
         end
       end
 
+      describe 'apptainer::install::os', if: facts[:os]['family'] == 'RedHat' do
+        let(:params) do
+          {
+            'install_method' => 'os',
+            'version' => '3.14'
+          }
+        end
+
+        it { is_expected.to contain_class('apptainer::install::os').that_comes_before('Class[apptainer::config]') }
+        it { is_expected.not_to contain_class('apptainer::install::source') }
+        it { is_expected.not_to contain_class('apptainer::install::package') }
+        it { is_expected.to contain_package('apptainer').with_ensure('3.14') }
+        it { is_expected.to contain_package('apptainer-suid').with_ensure('absent') }
+
+        describe 'with install_setuid true' do
+          let(:params) do
+            super().merge(install_setuid: true)
+          end
+
+          it { is_expected.to contain_package('apptainer').with_ensure('3.14') }
+          it { is_expected.to contain_package('apptainer-suid').with_ensure('3.14') }
+        end
+      end
+
       describe 'apptainer::install::source', if: facts[:os]['family'] == 'Debian' do
         it { is_expected.not_to contain_class('apptainer::install::package') }
         it { is_expected.to contain_class('apptainer::install::source').that_comes_before('Class[apptainer::config]') }


### PR DESCRIPTION
Now that apptainer is available from EPEL allow installations with traditional package installation.